### PR TITLE
Cross-platform Enhancement: Make tempfile writable on OS X

### DIFF
--- a/controller/add.py
+++ b/controller/add.py
@@ -17,7 +17,7 @@ def user_file_input(initial = "", extension = ".tmp", pre_hook = None, post_hook
 	If post_hook is not None, runs post_hook(tf.name, contents) after calling EDITOR.
 	"""
 
-	with tempfile.NamedTemporaryFile(suffix=extension) as tf:
+	with tempfile.NamedTemporaryFile(suffix=extension,dir='/tmp') as tf:
 		tf.write(initial.encode())
 		tf.flush()
 		if pre_hook is not None:


### PR DESCRIPTION
Hi Evan, thank you for creating this great script! It really helps on organizing problem sets.

However, when I first deploy this to my OSX machine, it doesn't work. After debugging I found it is because the temporary file created. The default result of `tempfile.gettempdir()` on mac is `/var/folders'. which is impossible to change the permission using `sudo chown`. Changing the writing location `/tmp` works, and it wouldn't change the script's function on Linux. Could you merge this? Thanks!