### PR TITLE
Fixes issue #13: Save problem text if YAML parsing errors

### DIFF
--- a/controller/add.py
+++ b/controller/add.py
@@ -135,6 +135,10 @@ def solicit_user_for_yaml(opts: Namespace, url: str) -> None | tuple[str, Any]:
             traceback.print_exc()
             alert_error_tryagain("Assertions failed, please try again.")
             initial = raw_yaml
+        except yaml.scanner.ScannerError:
+            traceback.print_exc()
+            alert_error_tryagain("Could not parse YAML, please try again.")
+            initial = raw_yaml
         else:
             del d["path"]
             # darn PyYAML used to do this fine -_-


### PR DESCRIPTION
Mainly because it's really sad to lose the solution you just wrote because YAML doesn't like colons not in a string.
