### PR TITLE
feat(puid): add custom lookup table in config

### DIFF
--- a/von/puid.py
+++ b/von/puid.py
@@ -1,6 +1,8 @@
 import hashlib
 import re
 
+from rc import VON_CUSTOM_LOOKUP
+
 lookup = {
     "Afghanistan": "AFG",
     "Albania": "ALB",
@@ -207,6 +209,7 @@ lookup["USAMO"] = "AMO"
 lookup["USAMTS"] = "USMT"
 lookup["USA GST"] = "USAEST"
 
+lookup.update(VON_CUSTOM_LOOKUP)
 # whooooo
 REGEX = r"(?P<contest>[a-zA-Z][a-zA-Z0-9 ]+)(19|20)(?P<year>[0-9][0-9])(?P<stem>[ \/](?P<locator>[0-9A-Za-z\.\/\- ]+))?$"
 re_generic = re.compile(REGEX)

--- a/von/puid.py
+++ b/von/puid.py
@@ -1,7 +1,7 @@
 import hashlib
 import re
 
-from rc import VON_CUSTOM_PUID
+from rc import VON_CUSTOM_LOOKUP
 
 lookup = {
     "Afghanistan": "AFG",
@@ -209,7 +209,7 @@ lookup["USAMO"] = "AMO"
 lookup["USAMTS"] = "USMT"
 lookup["USA GST"] = "USAEST"
 
-lookup.update(VON_CUSTOM_PUID)
+lookup.update(VON_CUSTOM_LOOKUP)
 # whooooo
 REGEX = r"(?P<contest>[a-zA-Z][a-zA-Z0-9 ]+)(19|20)(?P<year>[0-9][0-9])(?P<stem>[ \/](?P<locator>[0-9A-Za-z\.\/\- ]+))?$"
 re_generic = re.compile(REGEX)

--- a/von/puid.py
+++ b/von/puid.py
@@ -1,7 +1,7 @@
 import hashlib
 import re
 
-from rc import VON_CUSTOM_LOOKUP
+from rc import VON_CUSTOM_PUID
 
 lookup = {
     "Afghanistan": "AFG",
@@ -209,7 +209,7 @@ lookup["USAMO"] = "AMO"
 lookup["USAMTS"] = "USMT"
 lookup["USA GST"] = "USAEST"
 
-lookup.update(VON_CUSTOM_LOOKUP)
+lookup.update(VON_CUSTOM_PUID)
 # whooooo
 REGEX = r"(?P<contest>[a-zA-Z][a-zA-Z0-9 ]+)(19|20)(?P<year>[0-9][0-9])(?P<stem>[ \/](?P<locator>[0-9A-Za-z\.\/\- ]+))?$"
 re_generic = re.compile(REGEX)

--- a/von/rc.py
+++ b/von/rc.py
@@ -49,7 +49,15 @@ tags: ["trivial", "easy", "medium", "hard", "brutal"]
 
 # Name of text editor to invoke
 # By default, it detects from $EDITOR automatically
-# editor: vim"""
+# editor: vim
+
+# If you would like to define a custom contest name
+# (to be used in the PUID script), then you should
+# define it here. This will also override any "standard"
+# lookups in `puid.py`. (This should be in python dictionary
+# format)
+# lookups: {"contest-1": "abbreviation-1", "contest-2": "abbreviation-2"}
+"""
 
 if not CONFIG_DIR.exists():
     try:
@@ -111,6 +119,11 @@ elif sys.platform.startswith("darwin"):
     USER_OS = "mac"
 else:
     USER_OS = "linux"  # including cygwin
+
+if (custom_lookup := config.get("lookup")) is not None:
+    VON_CUSTOM_LOOKUP = custom_lookup
+else:
+    VON_CUSTOM_LOOKUP = {}
 
 # These used to be editable but I don't think it's worth it
 VON_INDEX_NAME = "index"

--- a/von/rc.py
+++ b/von/rc.py
@@ -56,7 +56,7 @@ tags: ["trivial", "easy", "medium", "hard", "brutal"]
 # define it here. This will also override any "standard"
 # lookups in `puid.py`. (This should be in python dictionary
 # format)
-# lookups: {"contest-1": "abbreviation-1", "contest-2": "abbreviation-2"}
+# lookup: {"contest-1": "abbreviation-1", "contest-2": "abbreviation-2"}
 """
 
 if not CONFIG_DIR.exists():

--- a/von/rc.py
+++ b/von/rc.py
@@ -51,12 +51,12 @@ tags: ["trivial", "easy", "medium", "hard", "brutal"]
 # By default, it detects from $EDITOR automatically
 # editor: vim
 
-# If you would like to define a custom contest name
-# (to be used in the PUID script), then you should
-# define it here. This will also override any "standard"
-# lookups in `puid.py`. (This should be in python dictionary
-# format)
-# lookup: {"contest-1": "abbreviation-1", "contest-2": "abbreviation-2"}
+# If you would like to define a custom contest name (to be used in the PUID script),
+# then you should define it here.
+# This will also override any "standard" lookups in `puid.py`.
+# abbreviations:
+#   Inter Galaxy Math Olympiad: IGMO
+#   Inter Universe Math Olympiad: IUMO
 """
 
 if not CONFIG_DIR.exists():
@@ -120,10 +120,7 @@ elif sys.platform.startswith("darwin"):
 else:
     USER_OS = "linux"  # including cygwin
 
-if (custom_lookup := config.get("lookup")) is not None:
-    VON_CUSTOM_LOOKUP = custom_lookup
-else:
-    VON_CUSTOM_LOOKUP = {}
+VON_CUSTOM_PUID = config.get("abbreviations", {})
 
 # These used to be editable but I don't think it's worth it
 VON_INDEX_NAME = "index"

--- a/von/rc.py
+++ b/von/rc.py
@@ -120,7 +120,7 @@ elif sys.platform.startswith("darwin"):
 else:
     USER_OS = "linux"  # including cygwin
 
-VON_CUSTOM_PUID = config.get("abbreviations", {})
+VON_CUSTOM_LOOKUP = config.get("abbreviations", {})
 
 # These used to be editable but I don't think it's worth it
 VON_INDEX_NAME = "index"


### PR DESCRIPTION
This is in response to a conversation on the OTIS discord about adding a custom lookup table in `rc.py`.