### PR TITLE
fix: remove leading space and other minor bugs

### DIFF
--- a/von/strparse.py
+++ b/von/strparse.py
@@ -75,10 +75,11 @@ def demacro(text: str) -> str:
 
 
 def remove_soft_newlines(text: str) -> str:
+    strip_text = "\n".join(line.lstrip() for line in text.splitlines())
     return re.sub(
         r"[a-zA-Z.,;—\"–'):$]\n[a-zA-Z$'\"]",
         lambda m: m.group(0).replace("\n", " "),
-        text,
+        strip_text,
     )
 
 
@@ -118,8 +119,8 @@ def toAOPS(text: str) -> str:
             "\n\n" + "[b][color=red]" + env.title() + ":[/color][/b] ",
         )
         text = text.replace(r"\end{" + env + "}", "")
-    text = text.replace(r"\begin{proof}", "[i]Proof.[/i] ")
-    text = text.replace(r"\end{proof}", r"$\blacksquare$" + "\n")
+    text = text.replace("\\begin{proof}\n", "[i]Proof.[/i] ")
+    text = text.replace("\n\\end{proof}", r" $\blacksquare$" + "\n")
     text = text.replace(r"\bigskip", DIVIDER)
     text = text.replace(r"\medskip", DIVIDER)
     text = text.replace(r"\#", "#")


### PR DESCRIPTION
Leading and trailing white-spaces in the copied TeX code (usually due to indentation) cause the script to fail. We use `lstrip` to strip the leading white-spaces. But since trailing white-spaces are more likely to be an error on the user's part, we do not remove that and let the script fail there so that the user realizes that their code has some trailing white-space and can fix it manually.

Moreover, we usually want the content inside claim to be right beside the title keyword and the QED to be at the end of the same line where the solution ends. Hence the other changes.